### PR TITLE
Support anonymous read access

### DIFF
--- a/config/git.conf
+++ b/config/git.conf
@@ -66,6 +66,14 @@ Alias /git /var/www/git
 <Location /git>
 	  AuthType Basic
 	  AuthName "Git Access"
-	  Require valid-user
+          AuthBasicProvider file anon
 	  AuthUserFile /var/lib/gitolite3/.gitolite/htpasswd
+
+          Anonymous_NoUserID on
+          Anonymous_MustGiveEmail off
+          Anonymous_VerifyEmail off
+          Anonymous_LogEmail off
+          Anonymous anonymous *
+
+	  Require valid-user
 </Location>


### PR DESCRIPTION
This commit add support for anonymous HTTP reads of git repos.  Access still needs to be granted at the gitolite level (through @all user for example).
